### PR TITLE
Make `glfw.Window.Hints.set` public

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -249,7 +249,7 @@ pub const Hints = struct {
         any = @bitCast(c.GLFW_ANY_POSITION),
     };
 
-    fn set(hints: Hints) void {
+    pub fn set(hints: Hints) void {
         internal_debug.assertInitialized();
         inline for (comptime std.meta.fieldNames(Hint)) |field_name| {
             const hint_tag = @intFromEnum(@field(Hint, field_name));

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -249,6 +249,9 @@ pub const Hints = struct {
         any = @bitCast(c.GLFW_ANY_POSITION),
     };
 
+    /// **WARNING:** You should always use `glfw.Window.create` instead of this function whenever possible. Only use this if absolutely neccessary.
+    ///
+    /// Sets `hints` for the next window creation.
     pub fn set(hints: Hints) void {
         internal_debug.assertInitialized();
         inline for (comptime std.meta.fieldNames(Hint)) |field_name| {


### PR DESCRIPTION
I would like to use it to add Graphics API specific hints  to my default hints:
```zig
const defaultHints = .{
    .visible = false,
    .resizable = false,
};
const graphicsApiHints = .{
    .opengl_profile = .opengl_core_profile,
    .context_version_major = 3,
    .context_version_minor = 3,
    .opengl_forward_compat = true,
}
defaultHints.set(); // would like to do this
graphicsApiHints.set(); // would like to do this
// Create window...
```

Current output:
```zig
src/App.zig:17:36: error: 'set' is not marked 'pub'
    rendering_backend.windowHints().set();
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
/home/tq/.cache/zig/p/122055be80f617e5a3b64bce8ad4dd0fcd8635ece0ae48c86f3bc9dd05e1ba6302fd/src/Window.zig:252:5: note: declared here
    fn set(hints: Hints) void {
    ^~~~~~~~~~~~~~~~~~~~~~~~~
```


- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.