### PR TITLE
Convert name in build.zig.zon to an identifier

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "mach-glfw",
+    .name = "mach_glfw",
     .version = "0.2.0",
     .paths = .{
         "src/",


### PR DESCRIPTION
When using `zig fetch --save ...` on this repo, the generated name for the dependency is `.@"mach-glfw"`. This PR changes the name of the package so the generated name is `.mach_glfw`, which is much nicer to read.

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.