### PR TITLE
Don't set the raw mouse motion input mode on macOS

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const testing = std.testing;
 const mem = std.mem;
 const c = @import("c.zig").c;
+const builtin = @import("builtin");
 
 const glfw = @import("main.zig");
 const Image = @import("Image.zig");
@@ -1563,10 +1564,14 @@ pub const InputModeCursor = enum(c_int) {
 pub inline fn setInputModeCursor(self: Window, value: InputModeCursor) void {
     if (value == .disabled) {
         self.setInputMode(.cursor, value);
-        return self.setInputMode(.raw_mouse_motion, true);
+        if(builtin.target.os.tag != .macos) { // Raw mouse motion is not supported on macOS
+            self.setInputMode(.raw_mouse_motion, true);
+        }
     }
     self.setInputMode(.cursor, value);
-    return self.setInputMode(.raw_mouse_motion, false);
+    if(builtin.target.os.tag != .macos) {
+        self.setInputMode(.raw_mouse_motion, false);
+    }
 }
 
 /// Gets the current input mode of the cursor.


### PR DESCRIPTION
Currently if you try to use the `setInputModeCursor` function on macOS, then GLFW will produce the following `error.PlatformError`: "Raw mouse motion is not supported on this system". This happens for every possible value parameter.
By checking if the platform is macOS, we can avoid this error.

Tested on Macbook Pro M1 with macOS Sonoma 14.5.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.