### PR TITLE
Revert "glfw: set raw_mouse_motion to true if cursor is disabled"

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1561,12 +1561,7 @@ pub const InputModeCursor = enum(c_int) {
 
 /// Sets the input mode of the cursor, whether it should behave normally, be hidden, or grabbed.
 pub inline fn setInputModeCursor(self: Window, value: InputModeCursor) void {
-    if (value == .disabled) {
-        self.setInputMode(.cursor, value);
-        return self.setInputMode(.raw_mouse_motion, true);
-    }
-    self.setInputMode(.cursor, value);
-    return self.setInputMode(.raw_mouse_motion, false);
+    return self.setInputMode(InputMode.cursor, value);
 }
 
 /// Gets the current input mode of the cursor.


### PR DESCRIPTION
This reverts commit 8e091cec7b328cda89ba7702b1bd9574efed8f9c.

Closes #48

I don't think it makes a lot of sense to have `setInputModeCursor` have a behavior that is different from the upstream GLFW. If you need to change both the cursor and raw mouse motion modes, you should call both `setInputModeCursor` and `setInputModeRawMouseMotion` separately.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.